### PR TITLE
Vpn modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,5 +152,19 @@ $ echo $?
 0
 ```
 
+## VPN Modules
+
+We have added two modules which can be used to identify VPN servers using OpenVPN over TCP, SSTP and PPTP.
+
+The SSTP module performs a TLS handshake, sends out an SSTP_DUPLEX_POST HTTP request and logs the server response. Other than the targets, no additional flag needs to be specified for the SSTP module to work. The default port is 443.
+
+The TCP module can be used to establish a TCP connection over which a specified probe will be sent to the target. The module includes features for an easier support of OpenVPN and PPTP probes. The default port is 443 and might have to be specified depending on the protocol (e.g. 1723 for PPTP). The following flags can be used in combination with the TCP module:
+
+ * `--hex`: Store response in hex value.
+ * `--keymethod`: Specifies OpenVPN key method. Can be eith 1 or 2.
+ * `--protocol`: Specifies which VPN protocol to scan for. Allows us to omit a probe.
+ * `--hmac`: Specify this flag to include HMAC, packet ID and timestamp in an OpenVPN request.
+ * `--probefile`: File which contains a custom probe to be sent over the TCP connection.
+
 ## License
 ZGrab2.0 is licensed under Apache 2.0 and ISC. For more information, see the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ The SSTP module performs a TLS handshake, sends out an SSTP_DUPLEX_POST HTTP req
 The TCP module can be used to establish a TCP connection over which a specified probe will be sent to the target. The module includes features for an easier support of OpenVPN and PPTP probes. The default port is 443 and might have to be specified depending on the protocol (e.g. 1723 for PPTP). The following flags can be used in combination with the TCP module:
 
  * `--hex`: Store response in hex value.
- * `--keymethod`: Specifies OpenVPN key method. Can be eith 1 or 2.
- * `--protocol`: Specifies which VPN protocol to scan for. Allows us to omit a probe.
+ * `--keymethod`: Specifies OpenVPN key method. This can be eith 1 or 2.
+ * `--protocol`: Specifies which VPN protocol to scan for. Allows us to omit a probe. This can be either *openvpn* or *pptp*.
  * `--hmac`: Specify this flag to include HMAC, packet ID and timestamp in an OpenVPN request.
  * `--probefile`: File which contains a custom probe to be sent over the TCP connection.
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,10 @@ The TCP module can be used to establish a TCP connection over which a specified 
 
  * `--hex`: Store response in hex value.
  * `--keymethod`: Specifies OpenVPN key method. This can be eith 1 or 2.
- * `--protocol`: Specifies which VPN protocol to scan for. Allows us to omit a probe. This can be either *openvpn* or *pptp*.
+ * `--protocol`: Specifies which VPN protocol to scan for. Allows us to omit a probe. This can be either *`openvpn`* or *`pptp`*.
  * `--hmac`: Specify this flag to include HMAC, packet ID and timestamp in an OpenVPN request.
  * `--probefile`: File which contains a custom probe to be sent over the TCP connection.
+ * `--session-id`: 8B session ID to use for OpenVPN request. The session ID can be used to identify and verify responses. The default ID is `1a2b3c4d1a2b3c4d`.
 
 ## License
 ZGrab2.0 is licensed under Apache 2.0 and ISC. For more information, see the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ The TCP module can be used to establish a TCP connection over which a specified 
  * `--protocol`: Specifies which VPN protocol to scan for. Allows us to omit a probe. This can be either *`openvpn`* or *`pptp`*.
  * `--hmac`: Specify this flag to include HMAC, packet ID and timestamp in an OpenVPN request.
  * `--probefile`: File which contains a custom probe to be sent over the TCP connection.
+ 
+    The probefile only contains the payload as a hex stream. For instance, to send the probe "Hello, World!" over TCP, specify a file containing the hex code "48656c6c6f2c20576f726c6421"
  * `--session-id`: 8B session ID to use for OpenVPN request. The session ID can be used to identify and verify responses. The default ID is `1a2b3c4d1a2b3c4d`.
+
+
 
 ## License
 ZGrab2.0 is licensed under Apache 2.0 and ISC. For more information, see the LICENSE file.

--- a/modules/sstp.go
+++ b/modules/sstp.go
@@ -1,0 +1,9 @@
+package modules
+
+import (
+	"github.com/zmap/zgrab2/modules/sstp"
+)
+
+func init() {
+	sstp.RegisterModule()
+}

--- a/modules/sstp/scanner.go
+++ b/modules/sstp/scanner.go
@@ -133,13 +133,15 @@ func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 
 	//establish TLS connection on top of tcp net.Conn object
 	conn := tls.Client(tcp_conn, cfg)
-	conn.SetDeadline(time.Now().Add(time.Duration(s.config.Timeout) * time.Second))
-
-	err = conn.Handshake()
 
 	if conn != nil {
 		defer conn.Close()
 	}
+
+	conn.SetDeadline(time.Now().Add(time.Duration(s.config.Timeout) * time.Second))
+
+	err = conn.Handshake()
+
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
@@ -176,36 +178,21 @@ func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 	for i, elem := range splits {
 		if i == 0 { //first element is the status message
 			status = elem
-			continue
-		}
-		if strings.Contains(elem, "Content-Length:") { //parse content length
+		} else if strings.Contains(elem, "Content-Length:") { //parse content length
 			c_length = elem
-			continue
-		}
-		if strings.Contains(elem, "Content-Type:") { //parse content type
+		} else if strings.Contains(elem, "Content-Type:") { //parse content type
 			c_type = elem
-			continue
-		}
-		if strings.Contains(elem, "Date:") { //skip date since zgrab logs the time anyway
-			continue
-		}
-		if strings.Contains(elem, "Host:") { //skip host
-			continue
-		}
-		if strings.Contains(elem, "Server:") { //parse server
+		} else if strings.Contains(elem, "Date:") { //skip date since zgrab logs the time anyway
+		} else if strings.Contains(elem, "Host:") { //skip host
+		} else if strings.Contains(elem, "Server:") { //parse server
 			server = elem
-			continue
-		}
-		if i == len(splits)-1 { //last element should be message body or empty
+		} else if i == len(splits)-1 { //last element should be message body or empty
 			if elem != "" {
 				if status == "HTTP/1.1 200 OK" {
 					body = elem
-					continue
 				}
 			}
-		}
-		//nothing matches, append to misc string and add line breaks again
-		if elem != "" {
+		} else if elem != "" { //nothing matches, append to misc string and add line breaks again
 			if status == "HTTP/1.1 200 OK" {
 				misc = misc + elem + "\r\n"
 			}
@@ -216,7 +203,7 @@ func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 	return zgrab2.SCAN_SUCCESS, &results, nil
 }
 
-// RegisterModule is called by modules/tcp.go to register this module with the
+// RegisterModule is called by modules/sstp.go to register this module with the
 // zgrab2 framework.
 func RegisterModule() {
 	var module TLSModule

--- a/modules/sstp/scanner.go
+++ b/modules/sstp/scanner.go
@@ -1,0 +1,228 @@
+// Package sstp contains the module implementation for SSTP HTTP(S) connection establishment
+//
+// The module performs a complete TLS handshake to then send an HTTP SSTP_DUPLEX_POST request. The default port is 443.
+package sstp
+
+import (
+	"crypto/tls"
+	"io"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zgrab2"
+)
+
+type TLSFlags struct {
+	zgrab2.BaseFlags
+	zgrab2.TLSFlags
+	File string `long:"file" default:"" description:"file to write responses to" `
+}
+
+type TLSScanner struct {
+	config *TLSFlags
+}
+
+type TLSModule struct {
+}
+
+// ScanResults instances are returned by the module's Scan function.
+type Results struct {
+	Status         string `json:"status,omitempty"`
+	Content_Length string `json:"content_length,omitempty"`
+	Host           string `json:"host,omitempty"`
+	Content_Type   string `json:"content_type,omitempty"`
+	Server         string `json:"server,omitempty"`
+	Misc           string `json:"misc,omitempty"`
+	Body           string `json:"body,omitempty"`
+}
+
+// NewFlags returns an empty Flags object.
+func (module *TLSModule) NewFlags() interface{} {
+	return new(TLSFlags)
+}
+
+// NewScanner returns a new instance Scanner instance.
+func (module *TLSModule) NewScanner() zgrab2.Scanner {
+	return new(TLSScanner)
+}
+
+// Help returns module-specific help
+func (flags *TLSFlags) Help() string {
+	return ""
+}
+
+// Protocol returns the protocol identifer for the scanner.
+func (scanner *TLSScanner) Protocol() string {
+	return "sstp"
+}
+
+// GetName returns the name defined in the Flags.
+func (scanner *TLSScanner) GetName() string {
+	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *TLSScanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
+// Description returns an overview of this module.
+func (module *TLSModule) Description() string {
+	return "Send an SSTP_DUPLEX_POST request and check if server accepts the response"
+}
+
+// InitPerSender does nothing in this module.
+func (scanner *TLSScanner) InitPerSender(senderID int) error {
+	return nil
+}
+
+func (f *TLSFlags) Validate(args []string) error {
+	return nil
+}
+
+// Init initializes the Scanner with the command-line flags.
+func (scanner *TLSScanner) Init(flags zgrab2.ScanFlags) error {
+	f, ok := flags.(*TLSFlags)
+	if !ok {
+		return zgrab2.ErrMismatchedFlags
+	}
+	scanner.config = f
+	return nil
+}
+
+func getProbe(host string) []byte {
+	first_part := "\x53\x53\x54\x50\x5f\x44\x55\x50\x4c\x45\x58\x5f\x50\x4f\x53\x54\x20\x2f\x73\x72\x61\x5f\x7b\x42\x41\x31\x39\x35\x39\x38\x30\x2d\x43\x44\x34\x39\x2d\x34\x35\x38\x62\x2d\x39\x45\x32\x33\x2d\x43\x38\x34\x45\x45\x30\x41\x44\x43\x44\x37\x35\x7d\x2f\x20\x48\x54\x54\x50\x2f\x31\x2e\x31\x0d\x0a\x53\x53\x54\x50\x43\x4f\x52\x52\x45\x4c\x41\x54\x49\x4f\x4e\x49\x44\x3a\x20\x7b\x31\x39\x37\x33\x30\x44\x36\x30\x2d\x39\x30\x41\x30\x2d\x34\x36\x32\x33\x2d\x38\x43\x34\x34\x2d\x36\x38\x38\x44\x37\x36\x32\x41\x41\x41\x31\x36\x7d\x0d\x0a\x43\x6f\x6e\x74\x65\x6e\x74\x2d\x4c\x65\x6e\x67\x74\x68\x3a\x20\x31\x38\x34\x34\x36\x37\x34\x34\x30\x37\x33\x37\x30\x39\x35\x35\x31\x36\x31\x35\x0d\x0a\x48\x6f\x73\x74\x3a\x20"
+	end_part := "\x0d\x0a\x0d\x0a"
+	complete_string := first_part + host + end_part
+	return []byte(complete_string)
+}
+
+// return tls config that skips hostname verification
+// this can be extended to, e.g., log SSL keys
+func tlsConfig() (*tls.Config, error) {
+	tlsConfig := tls.Config{
+		InsecureSkipVerify: true,
+	}
+	return &tlsConfig, nil
+}
+
+// Scan opens a TCP connection to the target (default port 443), then performs
+// a TLS handshake. If the handshake gets past the ServerHello stage, an SSTP_DUPLEX_POST
+// HTTP request is sent out and the response is logged
+func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	cfg, _ := tlsConfig()
+
+	var host string
+
+	//check if IP or domain name is passed and add it to the address to connect to
+	if t.IP != nil {
+		host = t.IP.String()
+	} else {
+		host = t.Host()
+		cfg.ServerName = host
+	}
+
+	//establish TCP connection
+	tcp_conn, err := t.Open(&s.config.BaseFlags)
+
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	defer tcp_conn.Close()
+
+	//establish TLS connection on top of tcp net.Conn object
+	conn := tls.Client(tcp_conn, cfg)
+	conn.SetDeadline(time.Now().Add(time.Duration(s.config.Timeout) * time.Second))
+
+	err = conn.Handshake()
+
+	if conn != nil {
+		defer conn.Close()
+	}
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+
+	//send probe and read response
+	probe := getProbe(host)
+	var (
+		readerr error
+		ret     []byte
+	)
+
+	_, err = conn.Write(probe)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	ret, readerr = zgrab2.ReadAvailable(conn)
+	if readerr != io.EOF && readerr != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+
+	//parse response
+	var results Results
+
+	splits := strings.Split(string(ret), "\r\n") //split by new lines
+
+	var status string
+	var c_length string
+	var c_type string
+	var server string
+	var misc string
+	var body string
+
+	//parse for specific header fields
+	for i, elem := range splits {
+		if i == 0 { //first element is the status message
+			status = elem
+			continue
+		}
+		if strings.Contains(elem, "Content-Length:") { //parse content length
+			c_length = elem
+			continue
+		}
+		if strings.Contains(elem, "Content-Type:") { //parse content type
+			c_type = elem
+			continue
+		}
+		if strings.Contains(elem, "Date:") { //skip date since zgrab logs the time anyway
+			continue
+		}
+		if strings.Contains(elem, "Host:") { //skip host
+			continue
+		}
+		if strings.Contains(elem, "Server:") { //parse server
+			server = elem
+			continue
+		}
+		if i == len(splits)-1 { //last element should be message body or empty
+			if elem != "" {
+				if status == "HTTP/1.1 200 OK" {
+					body = elem
+					continue
+				}
+			}
+		}
+		//nothing matches, append to misc string and add line breaks again
+		if elem != "" {
+			if status == "HTTP/1.1 200 OK" {
+				misc = misc + elem + "\r\n"
+			}
+		}
+	}
+	results = Results{Status: status, Content_Length: c_length, Server: server, Content_Type: c_type, Host: host, Misc: misc, Body: body}
+
+	return zgrab2.SCAN_SUCCESS, &results, nil
+}
+
+// RegisterModule is called by modules/tcp.go to register this module with the
+// zgrab2 framework.
+func RegisterModule() {
+	var module TLSModule
+
+	_, err := zgrab2.AddCommand("sstp", "SSTP request", module.Description(), 443, &module)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/modules/tcp.go
+++ b/modules/tcp.go
@@ -1,0 +1,9 @@
+package modules
+
+import (
+	"github.com/zmap/zgrab2/modules/tcp"
+)
+
+func init() {
+	tcp.RegisterModule()
+}

--- a/modules/tcp/scanner.go
+++ b/modules/tcp/scanner.go
@@ -21,7 +21,7 @@ import (
 type Flags struct {
 	zgrab2.BaseFlags
 
-	Protocol  string `long:"protocol" default:"\\n" description:"Send an initiation request of the VPN protocol specified here. This can be either 'pptp' or 'openvpn'" `
+	Protocol  string `long:"protocol" default:"\\n" description:"Send an initiation request of the VPN protocol specified here. This can be either 'pptp' or 'openvpn'. Mutually exclusive with --probe-file." `
 	ProbeFile string `long:"probe-file" description:"Read probe from file as hex stream and convert to byte array. Mutually exclusive with --protocol."`
 	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
 	Hex       bool   `long:"hex" description:"Store banner value in hex. "`

--- a/modules/tcp/scanner.go
+++ b/modules/tcp/scanner.go
@@ -1,0 +1,234 @@
+// Package tcp contains the module implementation for TCP
+//
+// The module performs a complete TCP handshake to then send TCP packages. The default port is 443
+package tcp
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zgrab2"
+)
+
+type Flags struct {
+	zgrab2.BaseFlags
+	zgrab2.TLSFlags
+
+	Protocol  string `long:"protocol" default:"\\n" description:"Send an initiation request of the VPN protocol specified here." `
+	ProbeFile string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe"`
+	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
+	Hex       bool   `long:"hex" description:"Store banner value in hex. "`
+	File      string `long:"file" default:"" description:"file to write responses to" `
+	HMAC      bool   `long:"hmac" description:"Specify if HMAC should be used in OpenVPN request"`
+	KeyMethod int    `long:"keymethod" default:"2" description:"Specify which KeyMethod to use for OpenVPN"`
+}
+
+// Module is an implementation of the zgrab2.Module interface.
+type Module struct {
+}
+
+// Scanner is the implementation of the zgrab2.Scanner interface.
+type Scanner struct {
+	config *Flags
+	probe  []byte
+}
+
+// ScanResults instances are returned by the module's Scan function.
+type Results struct {
+	Response string `json:"response,omitempty"`
+}
+
+// NewFlags returns an empty Flags object.
+func (module *Module) NewFlags() interface{} {
+	return new(Flags)
+}
+
+// NewScanner returns a new instance Scanner instance.
+func (module *Module) NewScanner() zgrab2.Scanner {
+	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Send a TCP probe and read the response"
+}
+
+// Validate performs any needed validation on the arguments
+func (flags *Flags) Validate(args []string) error {
+	if flags.Protocol != "\\n" && flags.ProbeFile != "" {
+		log.Fatal("Cannot set both --probe and --probe-file")
+		return zgrab2.ErrInvalidArguments
+	}
+	return nil
+}
+
+// Help returns module-specific help
+func (flags *Flags) Help() string {
+	return ""
+}
+
+// Protocol returns the protocol identifer for the scanner.
+func (scanner *Scanner) Protocol() string {
+	return "tcp"
+}
+
+// GetName returns the name defined in the Flags.
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
+// InitPerSender does nothing in this module.
+func (scanner *Scanner) InitPerSender(senderID int) error {
+	return nil
+}
+
+// Init initializes the Scanner with the command-line flags.
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
+	var err error
+	f, _ := flags.(*Flags)
+	scanner.config = f
+	if len(f.ProbeFile) != 0 {
+		scanner.probe, err = ioutil.ReadFile(f.ProbeFile)
+		if err != nil {
+			log.Fatal("Failed to open probe file")
+			return zgrab2.ErrInvalidArguments
+		}
+	} else {
+		if len(scanner.probe) == 0 {
+			strProtocol, err := strconv.Unquote(fmt.Sprintf(`"%s"`, scanner.config.Protocol))
+			strProbe := ""
+			opcode := ""
+			if err != nil {
+				panic("Probe error")
+			}
+			//determine which probe to use
+			if strProtocol == "pptp" {
+				strProbe = "\x00\x9c\x00\x01\x1a\x2b\x3c\x4d\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x4d\x69\x63\x72\x6f\x73\x6f\x66\x74\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+				scanner.probe = []byte(strProbe)
+			}
+			if strProtocol == "openvpn" {
+				length := ""
+
+				//generate session ID
+				//the ID is static in order to identify and verify incoming responses
+				session := "1a2b3c4d1a2b3c4d"
+
+				//generate opcode
+				if scanner.config.KeyMethod == 1 {
+					opcode = "08"
+				}
+
+				if scanner.config.KeyMethod == 2 {
+					opcode = "38"
+				}
+
+				//check if hmac should be included
+				if !scanner.config.HMAC {
+					length = "000e"
+					strProbe = length + opcode + session + "0000000000"
+				}
+				if f.HMAC { //hmac generation
+					length = "002a"
+					hmac := hmac.New(sha1.New, []byte("secret"))
+					hmac.Write([]byte(length + opcode + session))
+					hash := hex.EncodeToString((hmac.Sum(nil)))
+
+					//get timestamp
+					timestamp := strconv.FormatInt(time.Now().Unix(), 16)
+
+					packet_id := "00000001"
+
+					//put everything together
+					strProbe = length + opcode + session + hash + packet_id + timestamp + "0000000000"
+				}
+				scanner.probe, _ = hex.DecodeString(strProbe)
+			}
+		}
+	}
+	return nil
+}
+
+// Scan opens a TCP connection to the target (default port 443), then performs
+// a TLS handshake. If the handshake gets past the ServerHello stage, the
+// handshake log is returned (along with any other TLS-related logs, such as
+// heartbleed, if enabled).
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	try := 0
+	var (
+		conn    net.Conn
+		err     error
+		readerr error
+	)
+
+	//try to open connection for specified amount of tries
+	for try < scanner.config.MaxTries {
+		try++
+		conn, err = target.Open(&scanner.config.BaseFlags)
+		if err != nil {
+			continue
+		}
+
+		break
+	}
+
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+
+	defer conn.Close()
+
+	//send probe to open connection and check for response
+	var ret []byte
+	try = 0
+	for try < scanner.config.MaxTries {
+		try++
+		_, err = conn.Write(scanner.probe)
+		ret, readerr = zgrab2.ReadAvailable(conn)
+		if err != nil {
+			continue
+		}
+		if readerr != io.EOF && readerr != nil {
+			continue
+		}
+		break
+	}
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	if readerr != io.EOF && readerr != nil {
+		return zgrab2.TryGetScanStatus(readerr), nil, readerr
+	}
+
+	var results Results
+	if scanner.config.Hex {
+		results = Results{Response: hex.EncodeToString(ret)}
+	} else {
+		results = Results{Response: string(ret)}
+	}
+
+	return zgrab2.SCAN_SUCCESS, &results, nil
+}
+
+// RegisterModule is called by modules/tcp.go to register this module with the
+// zgrab2 framework.
+func RegisterModule() {
+	var module Module
+
+	_, err := zgrab2.AddCommand("tcp", "TCP probe", module.Description(), 443, &module)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/zgrab2_schemas/zgrab2/__init__.py
+++ b/zgrab2_schemas/zgrab2/__init__.py
@@ -21,3 +21,5 @@ from . import ssh
 from . import telnet
 from . import ipp
 from . import banner
+from . import tcp
+from . import sstp

--- a/zgrab2_schemas/zgrab2/sstp.py
+++ b/zgrab2_schemas/zgrab2/sstp.py
@@ -1,0 +1,25 @@
+# zschema sub-schema for zgrab2's sstp module
+# Registers zgrab2-sstp globally, and sstp with the main zgrab2 schema.
+from zschema.leaves import *
+from zschema.compounds import *
+import zschema.registry
+
+import zcrypto_schemas.zcrypto as zcrypto
+from . import zgrab2
+
+# modules/tcp/scanner.go - Results
+sstp_scan_response = SubRecord({
+    "result": SubRecord({
+        "status": String(),
+        "content-length": String(),
+        "host": String(),
+        "content-type": String(),
+        "server": String(),
+        "misc": String(),
+        "body": String()
+    })
+}, extends=zgrab2.base_scan_response)
+
+zschema.registry.register_schema("zgrab2-sstp", sstp_scan_response)
+
+zgrab2.register_scan_response_type("sstp", sstp_scan_response)

--- a/zgrab2_schemas/zgrab2/tcp.py
+++ b/zgrab2_schemas/zgrab2/tcp.py
@@ -1,0 +1,19 @@
+# zschema sub-schema for zgrab2's tcp module
+# Registers zgrab2-tcp globally, and tcp with the main zgrab2 schema.
+from zschema.leaves import *
+from zschema.compounds import *
+import zschema.registry
+
+import zcrypto_schemas.zcrypto as zcrypto
+from . import zgrab2
+
+# modules/tcp/scanner.go - Results
+tcp_scan_response = SubRecord({
+    "result": SubRecord({
+        "response": String(),
+    })
+}, extends=zgrab2.base_scan_response)
+
+zschema.registry.register_schema("zgrab2-tcp", tcp_scan_response)
+
+zgrab2.register_scan_response_type("tcp", tcp_scan_response)


### PR DESCRIPTION
Add modules to send out VPN requests including:

- TCP module: Establish TCP connection and send out probe
- SSTP module: Establish TLS connection and send out SSTP_DUPLEX_POST HTTP request